### PR TITLE
Use git-up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ make the life easier and will avoid wasting time on things which are not
 requested. :sparkles:
 
 ## Discuss the changes before doing them
- - First of all, open an issue in the repository, using the [bug tracker][1],
+ - First of all, open an issue in the repository, using the [bug tracker][1]
    describing the contribution you'd like to make, the bug you found or any
    other ideas you have. This will help us to get you started on the right
    foot.
@@ -57,4 +57,5 @@ Finally, your contributions will be merged, and everyone will be happy! :smile:
 Thanks! :sweat_smile:
 
 [1]: https://github.com/IonicaBizau/node-git-url-parse/issues
+
 [2]: https://github.com/IonicaBizau/code-style

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # git-url-parse [![Donate now][donate-now]][paypal-donations]
 
-Parses and stringifies git urls.
+A high level git url parser for common git providers.
 
 ## Installation
 
@@ -32,26 +32,46 @@ $ npm i git-url-parse
 var GitUrlParse = require("git-url-parse");
 
 console.log(GitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git"));
-// => { protocol: 'ssh'
-//    , source: 'github.com'
-//    , owner: 'IonicaBizau'
-//    , name: 'node-git-url-parse'
-//    , _: 'git@github.com:IonicaBizau/node-git-url-parse.git'
-//    , toString: [Function] }
+// => {
+//     protocols: []
+//   , port: null
+//   , resource: "github.com"
+//   , user: "git"
+//   , pathname: "/IonicaBizau/node-git-url-parse.git"
+//   , hash: ""
+//   , search: ""
+//   , href: "git@github.com:IonicaBizau/node-git-url-parse.git"
+//   , token: ""
+//   , protocol: "ssh"
+//   , toString: [Function]
+//   , source: "github.com"
+//   , name: "node-git-url-parse"
+//   , owner: "IonicaBizau"
+// } {
 
 console.log(GitUrlParse("https://github.com/IonicaBizau/node-git-url-parse.git"));
-// => { protocol: 'https'
-//    , source: 'github.com'
-//    , owner: 'IonicaBizau'
-//    , name: 'node-git-url-parse'
-//    , _: 'https://github.com/IonicaBizau/node-git-url-parse.git'
-//    , toString: [Function] }
+// => {
+//     protocols: ["https"]
+//   , port: null
+//   , resource: "github.com"
+//   , user: ""
+//   , pathname: "/IonicaBizau/node-git-url-parse.git"
+//   , hash: ""
+//   , search: ""
+//   , href: "https://github.com/IonicaBizau/node-git-url-parse.git"
+//   , token: ""
+//   , protocol: "https"
+//   , toString: [Function]
+//   , source: "github.com"
+//   , name: "node-git-url-parse"
+//   , owner: "IonicaBizau"
+// }
 
 console.log(GitUrlParse("https://github.com/IonicaBizau/node-git-url-parse.git").toString("ssh"));
-// => 'git@github.com:IonicaBizau/node-git-url-parse.git.git'
+// => "git@github.com:IonicaBizau/node-git-url-parse.git"
 
 console.log(GitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git").toString("https"));
-// => 'https://github.com/IonicaBizau/node-git-url-parse.git'
+// => "https://github.com/IonicaBizau/node-git-url-parse.git"
 
 ```
 
@@ -65,12 +85,21 @@ Parses a Git url.
 
 #### Return
 - **GitUrl** The `GitUrl` object containing:
- - `protocol` (String): The url protocol.
+ - `protocols` (Array): An array with the url protocols (usually it has one element).
+ - `port` (null|Number): The domain port.
+ - `resource` (String): The url domain (including subdomains).
+ - `user` (String): The authentication user (usually for ssh urls).
+ - `pathname` (String): The url pathname.
+ - `hash` (String): The url hash.
+ - `search` (String): The url querystring value.
+ - `href` (String): The input url.
+ - `protocol` (String): The git url protocol.
+ - `token` (String): The oauth token (could appear in the https urls).
  - `source` (String): The Git provider (e.g. `"github.com"`).
  - `owner` (String): The repository owner.
  - `name` (String): The repository name.
- - `_` (String): The original url which was parsed.
  - `toString` (Function): A function to stringify the parsed url into another url type.
+ - `organization` (String): The organization the owner belongs to. This is CloudForge specific.
 
 ### `stringify(obj, type)`
 Stringifies a `GitUrl` object.

--- a/example/index.js
+++ b/example/index.js
@@ -2,23 +2,43 @@
 var GitUrlParse = require("../lib");
 
 console.log(GitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git"));
-// => { protocol: 'ssh'
-//    , source: 'github.com'
-//    , owner: 'IonicaBizau'
-//    , name: 'node-git-url-parse'
-//    , _: 'git@github.com:IonicaBizau/node-git-url-parse.git'
-//    , toString: [Function] }
+// => {
+//     protocols: []
+//   , port: null
+//   , resource: "github.com"
+//   , user: "git"
+//   , pathname: "/IonicaBizau/node-git-url-parse.git"
+//   , hash: ""
+//   , search: ""
+//   , href: "git@github.com:IonicaBizau/node-git-url-parse.git"
+//   , token: ""
+//   , protocol: "ssh"
+//   , toString: [Function]
+//   , source: "github.com"
+//   , name: "node-git-url-parse"
+//   , owner: "IonicaBizau"
+// } {
 
 console.log(GitUrlParse("https://github.com/IonicaBizau/node-git-url-parse.git"));
-// => { protocol: 'https'
-//    , source: 'github.com'
-//    , owner: 'IonicaBizau'
-//    , name: 'node-git-url-parse'
-//    , _: 'https://github.com/IonicaBizau/node-git-url-parse.git'
-//    , toString: [Function] }
+// => {
+//     protocols: ["https"]
+//   , port: null
+//   , resource: "github.com"
+//   , user: ""
+//   , pathname: "/IonicaBizau/node-git-url-parse.git"
+//   , hash: ""
+//   , search: ""
+//   , href: "https://github.com/IonicaBizau/node-git-url-parse.git"
+//   , token: ""
+//   , protocol: "https"
+//   , toString: [Function]
+//   , source: "github.com"
+//   , name: "node-git-url-parse"
+//   , owner: "IonicaBizau"
+// }
 
 console.log(GitUrlParse("https://github.com/IonicaBizau/node-git-url-parse.git").toString("ssh"));
-// => 'git@github.com:IonicaBizau/node-git-url-parse.git.git'
+// => "git@github.com:IonicaBizau/node-git-url-parse.git"
 
 console.log(GitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git").toString("https"));
-// => 'https://github.com/IonicaBizau/node-git-url-parse.git'
+// => "https://github.com/IonicaBizau/node-git-url-parse.git"

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,13 +20,11 @@ var GitUp = require("git-up");
  *  - `href` (String): The input url.
  *  - `protocol` (String): The git url protocol.
  *  - `token` (String): The oauth token (could appear in the https urls).
- *
- *  - `protocol` (String): The url protocol.
  *  - `source` (String): The Git provider (e.g. `"github.com"`).
  *  - `owner` (String): The repository owner.
  *  - `name` (String): The repository name.
- *  - `href` (String): The original url which was parsed.
  *  - `toString` (Function): A function to stringify the parsed url into another url type.
+ *  - `organization` (String): The organization the owner belongs to. This is CloudForge specific.
  */
 function GitUrlParse(url) {
 
@@ -50,6 +48,7 @@ function GitUrlParse(url) {
 
     urlInfo.name = urlInfo.pathname.substring(1).replace(/\.git$/, "");
     urlInfo.owner = urlInfo.user;
+    urlInfo.organization = urlInfo.owner;
 
     switch (urlInfo.source) {
         case "cloudforge.com":

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+// Dependencies
+var GitUp = require("git-up");
+
 /**
  * GitUrlParse
  * Parses a Git url.
@@ -7,11 +10,22 @@
  * @param {String} url The Git url to parse.
  * @return {GitUrl} The `GitUrl` object containing:
  *
+ *  - `protocols` (Array): An array with the url protocols (usually it has one element).
+ *  - `port` (null|Number): The domain port.
+ *  - `resource` (String): The url domain (including subdomains).
+ *  - `user` (String): The authentication user (usually for ssh urls).
+ *  - `pathname` (String): The url pathname.
+ *  - `hash` (String): The url hash.
+ *  - `search` (String): The url querystring value.
+ *  - `href` (String): The input url.
+ *  - `protocol` (String): The git url protocol.
+ *  - `token` (String): The oauth token (could appear in the https urls).
+ *
  *  - `protocol` (String): The url protocol.
  *  - `source` (String): The Git provider (e.g. `"github.com"`).
  *  - `owner` (String): The repository owner.
  *  - `name` (String): The repository name.
- *  - `_` (String): The original url which was parsed.
+ *  - `href` (String): The original url which was parsed.
  *  - `toString` (Function): A function to stringify the parsed url into another url type.
  */
 function GitUrlParse(url) {
@@ -20,52 +34,35 @@ function GitUrlParse(url) {
         throw new Error("The url must be a string.");
     }
 
-    var urlInfo = {
-            protocol: null
-          , source: null
-          , owner: null
-          , name: null
-          , _: url
-          , toString: function (type) {
-                return GitUrlParse.stringify(this, type);
-            }
-        }
-      , match = null
+    var urlInfo = GitUp(url)
+      , sourceParts = urlInfo.resource.split(".")
+      , splits = null
       ;
 
-    // SSH protocol
-    check_git: if (/^git\@/.test(url)) {
-        match = url.match(/^git@(.*):(.*)\/(.*).git$/);
-        if (!match) { break check_git; }
-        urlInfo.source = match[1];
-        urlInfo.owner = match[2];
-        urlInfo.name = match[3];
-        urlInfo.protocol = "ssh";
-    } else
+    urlInfo.toString = function (type) {
+        return GitUrlParse.stringify(this, type);
+    };
 
-    // HTTP(S) protocol
-    check_https: if (/^https?:\/\//.test(url)) {
-        url = url.replace(/(\/|\.git)$/, "");
-        match = url.match(/^(https?):\/\/(.*)\/(.*)\/(.*)\/?$/);
-        if (!match) { break check_https; }
-        urlInfo.protocol = match[1];
-        urlInfo.source = match[2];
-        urlInfo.owner = match[3];
-        urlInfo.name = match[4];
-    } else
+    urlInfo.source = sourceParts.length > 2
+                   ? sourceParts.slice(-2).join(".")
+                   : urlInfo.source = urlInfo.resource
+                   ;
 
-    // git+ssh protocol
-    check_gitssh: if (/^git\+ssh:\/\/git\@/.test(url)) {
-        url = url.replace(/\.git$/, "");
-        match = url.match(/^git\+ssh:\/\/git\@(.*)\/(.*)\/(.*)\/?$/);
-        if (!match) { break check_gitssh; }
-        urlInfo.protocol = "git+ssh";
-        urlInfo.source = match[1];
-        urlInfo.owner = match[2];
-        urlInfo.name = match[3];
-    } else {
-        urlInfo.protocol = "file";
-        // Feel free to add more parsers
+    urlInfo.name = urlInfo.pathname.substring(1).replace(/\.git$/, "");
+    urlInfo.owner = urlInfo.user;
+
+    switch (urlInfo.source) {
+        case "cloudforge.com":
+            urlInfo.owner = urlInfo.user;
+            urlInfo.organization = sourceParts[0];
+            break;
+        default:
+            splits = urlInfo.name.split("/");
+            if (splits.length === 2) {
+                urlInfo.owner = splits[0];
+                urlInfo.name = splits[1];
+            }
+            break;
     }
 
     return urlInfo;
@@ -92,7 +89,7 @@ GitUrlParse.stringify = function (obj, type) {
         case "https":
             return type + "://" + obj.source + "/" + obj.owner + "/" + obj.name + ".git";
         default:
-            return obj._;
+            return obj.href;
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-url-parse",
   "version": "3.0.0",
-  "description": "Parses and stringifies git urls.",
+  "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha"
@@ -23,8 +23,5 @@
   "homepage": "https://github.com/IonicaBizau/node-git-url-parse",
   "blah": {
       "h_img": "http://i.imgur.com/HlfMsVf.png"
-  },
-  "devDependencies": {
-    "mocha": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
   },
   "homepage": "https://github.com/IonicaBizau/node-git-url-parse",
   "blah": {
-      "h_img": "http://i.imgur.com/HlfMsVf.png"
+    "h_img": "http://i.imgur.com/HlfMsVf.png"
+  },
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "dependencies": {
+    "git-up": "^1.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-url-parse",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -96,6 +96,7 @@ it("should parse CloudForge urls", function (cb) {
     var res = GitUrlParse("https://owner@organization.git.cloudforge.com/name.git");
     Assert.strictEqual(res.source, "cloudforge.com");
     Assert.strictEqual(res.owner, "owner");
+    Assert.strictEqual(res.organization, "organization");
     Assert.strictEqual(res.name, "name");
     cb();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ it("should parse ssh urls", function (cb) {
     Assert.strictEqual(res.source, "github.com");
     Assert.strictEqual(res.owner, "IonicaBizau");
     Assert.strictEqual(res.name, "node-giturlparse");
-    Assert.strictEqual(res._, URLS.ssh);
+    Assert.strictEqual(res.href, URLS.ssh);
     Assert.strictEqual(res.toString("https"), URLS.https);
     Assert.strictEqual(res.toString("git+ssh"), URLS.gitSsh);
     Assert.strictEqual(res.toString("ssh"), URLS.ssh);
@@ -31,7 +31,7 @@ it("should parse https urls", function (cb) {
     Assert.strictEqual(res.source, "github.com");
     Assert.strictEqual(res.owner, "IonicaBizau");
     Assert.strictEqual(res.name, "node-giturlparse");
-    Assert.strictEqual(res._, URLS.https);
+    Assert.strictEqual(res.href, URLS.https);
     Assert.strictEqual(res.toString("https"), URLS.https);
     Assert.strictEqual(res.toString("git+ssh"), URLS.gitSsh);
     Assert.strictEqual(res.toString("ssh"), URLS.ssh);
@@ -54,12 +54,48 @@ it("should parse https urls with ending slash", function (cb) {
 // git+ssh protocol
 it("should parse git+ssh urls", function (cb) {
     var res = GitUrlParse(URLS.gitSsh);
-    Assert.strictEqual(res.protocol, "git+ssh");
+    Assert.strictEqual(res.protocol, "ssh");
     Assert.strictEqual(res.source, "github.com");
     Assert.strictEqual(res.owner, "IonicaBizau");
     Assert.strictEqual(res.name, "node-giturlparse");
     Assert.strictEqual(res.toString("https"), URLS.https);
     Assert.strictEqual(res.toString("git+ssh"), URLS.gitSsh);
     Assert.strictEqual(res.toString("ssh"), URLS.ssh);
+    cb();
+});
+
+// oauth
+it("should parse oauth urls", function (cb) {
+    var res = GitUrlParse("https://token:x-oauth-basic@github.com/owner/name.git");
+    Assert.strictEqual(res.source, "github.com");
+    Assert.strictEqual(res.owner, "owner");
+    Assert.strictEqual(res.name, "name");
+    cb();
+});
+
+// oauth bitbucket
+it("should parse Bitbucket oauth urls", function (cb) {
+    var res = GitUrlParse("https://x-token-auth:token@bitbucket.org/owner/name.git");
+    Assert.strictEqual(res.source, "bitbucket.org");
+    Assert.strictEqual(res.owner, "owner");
+    Assert.strictEqual(res.name, "name");
+    cb();
+});
+
+// https bitbucket
+it("should parse Bitbucket https urls", function (cb) {
+    var res = GitUrlParse("https://owner@bitbucket.org/owner/name");
+    Assert.strictEqual(res.source, "bitbucket.org");
+    Assert.strictEqual(res.owner, "owner");
+    Assert.strictEqual(res.name, "name");
+    cb();
+});
+
+// https cloudforge
+it("should parse CloudForge urls", function (cb) {
+    var res = GitUrlParse("https://owner@organization.git.cloudforge.com/name.git");
+    Assert.strictEqual(res.source, "cloudforge.com");
+    Assert.strictEqual(res.owner, "owner");
+    Assert.strictEqual(res.name, "name");
     cb();
 });


### PR DESCRIPTION
I was building a bunch of little libraries to support a better parsing:

 - [`git-up`](https://github.com/IonicaBizau/node-git-up)
   - [`is-ssh`](https://github.com/IonicaBizau/node-is-ssh)
   - [`parse-url`](https://github.com/IonicaBizau/node-parse-url)
     - [`protocols`](https://github.com/IonicaBizau/node-protocols)

Honestly, when I wrote this library I totally forgot that the git url is not only in `host/owner/name` format but it could be any valid git url. In fact, I didn't consider the custom git servers for example.

However, this should be gone now. Using [`git-up`](https://github.com/IonicaBizau/node-git-up), this library should support more providers. Explicitly, `git-url-parse` supports the common git providers urls (if you have a limitation, [contributions](https://github.com/IonicaBizau/node-git-url-parse/blob/master/CONTRIBUTING.md) are always welcome).

For low level git url parsing, refer to [`git-up`](https://github.com/IonicaBizau/node-git-up) or [`parse-url`](https://github.com/IonicaBizau/node-parse-url), for even lower level. :smile: 

This change is supposed to fix #9.
Also, using the [`parse-url`](https://github.com/IonicaBizau/node-parse-url) library, oauth are also supported. Fixes #10.

Same goes for multiple protocols. Fixes #8. :dizzy: 